### PR TITLE
Simplified containers with Unit as Python runtime

### DIFF
--- a/objective2/Dockerfile
+++ b/objective2/Dockerfile
@@ -1,12 +1,8 @@
-FROM python:3.11 as builder
+FROM alpine as cloner
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git-lfs \
-    && git lfs install \
-    && git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization \
-    && rm -rf /tmp/model/.git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add git-lfs
+RUN git lfs install
+RUN git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization
 
 FROM quay.io/jupyter/pytorch-notebook
-
-COPY --from=builder /tmp/model /home/jovyan/model
+COPY --from=cloner /tmp/model /home/jovyan/model

--- a/objective2/README.md
+++ b/objective2/README.md
@@ -23,18 +23,14 @@ For this lab, we will create a new Jupyter Notebook container based on the [PyTo
 We will use the Dockerfile in this repository under the _objective2_ folder with the contents below:
 
 ```docker
-FROM python:3.11 as builder
+FROM alpine as cloner
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git-lfs \
-    && git lfs install \
-    && git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization \
-    && rm -rf /tmp/model/.git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add git-lfs
+RUN git lfs install
+RUN git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization
 
 FROM quay.io/jupyter/pytorch-notebook
-
-COPY --from=builder /tmp/model /home/jovyan/model
+COPY --from=cloner /tmp/model /home/jovyan/model
 ```
 
 A more detailed overview of the Dockerfile will be provided in _objective3_.
@@ -44,6 +40,8 @@ To build the container, run the following command below in the _objective2_ dire
 ```shell
 docker build -t llmapi_obj2 .
 ```
+
+> **NOTE:** The resulting Docker image will be very large (7-8GB)
 
 ## Deploy Jupyter Server
 

--- a/objective3/Dockerfile
+++ b/objective3/Dockerfile
@@ -1,24 +1,17 @@
-FROM python:3.11 as builder
+FROM alpine as cloner
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git-lfs \
-    && git lfs install \
-    && git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization \
-    && rm -rf /tmp/model/.git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add git-lfs
+RUN git lfs install
+RUN git clone https://huggingface.co/Falconsai/text_summarization /tmp/model/text_summarization
 
-FROM python:3.11
+FROM unit:python
 
-WORKDIR /code
+WORKDIR /code/app
 
-COPY requirements.txt /code/requirements.txt
+COPY requirements.txt app/api.py .
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY --from=cloner /tmp/model /code/app/model
+RUN chown -R unit:unit .
 
-RUN mkdir -p /code/app
-
-COPY ./app /code/app
-
-COPY --from=builder /tmp/model /code/app/model
-
-CMD ["uvicorn", "app.api:app", "--host", "0.0.0.0", "--port", "80"]
+COPY unitconf.json /docker-entrypoint.d/

--- a/objective3/requirements.txt
+++ b/objective3/requirements.txt
@@ -2,4 +2,3 @@ fastapi>=0.110.1
 pydantic>=2.6.4
 transformers>=4.39.3
 torch>=2.2.2
-uvicorn>=0.29.0

--- a/objective3/unitconf.json
+++ b/objective3/unitconf.json
@@ -1,0 +1,18 @@
+{
+	"listeners": {
+		"*:80": {
+			"pass": "applications/ts"
+		}
+	},
+	"applications": {
+		"ts": {
+			"type": "python",
+			"path": "/code/app",
+			"module": "api",
+			"callable": "app",
+			"environment": {
+				"HF_HOME": "/code/app"
+			}
+		}
+	}
+}


### PR DESCRIPTION
My motivation was to swap out Univorn for NGINX Unit in objective 3.

Along the way I simplified the Dockerfile and then back-ported it to objective 2 to benefit from Docker caching, because they are big!

Also removed the requirement for `jq` in objective 3 and simplified the `curl` command but this may not align with the lab goals/expectations.